### PR TITLE
Fix reverse selectedEntities order to get correct order after useEntityList

### DIFF
--- a/packages/admin/src/components/bindingFacade/upload/internalComponents/selection/SelectFileInput.tsx
+++ b/packages/admin/src/components/bindingFacade/upload/internalComponents/selection/SelectFileInput.tsx
@@ -73,7 +73,7 @@ export const SelectFileInput = Component(
 				),
 			})
 			if (selectedEntities !== undefined) {
-				onSelectConfirm(selectedEntities)
+				onSelectConfirm(selectedEntities.reverse())
 			}
 		}, [accessorTree, fileSelection, formatMessage, insertSelectedText, isMultiple, onSelectConfirm, openDialog, selectButtonText])
 


### PR DESCRIPTION
It is the easist fix how to get correct ordering of selected photos, but I doubt it is the best.

The entities gets incorrect (reverse) order after calling [`useEntityList` in `Repeater`](https://github.com/contember/interface/blob/main/packages/admin/src/components/bindingFacade/collections/Repeater/Repeater.tsx#L35) and then they are sorted in [`RepeaterInner`](https://github.com/contember/interface/blob/main/packages/admin/src/components/bindingFacade/collections/Repeater/RepeaterInner.tsx#L63) by order (passed in props)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/469)
<!-- Reviewable:end -->
