### PR TITLE
Add types from `vite/client` to support `import.meta.env.DEV`

### DIFF
--- a/build/api/binding.api.md
+++ b/build/api/binding.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { ComponentType } from 'react';
 import type { CrudQueryBuilder } from '@contember/client';
 import { EmbeddedActionsParser } from 'chevrotain';

--- a/build/api/react-client.api.md
+++ b/build/api/react-client.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { ComponentType } from 'react';
 import { Context } from 'react';
 import type { FileUploader } from '@contember/client';

--- a/build/api/react-utils.api.md
+++ b/build/api/react-utils.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { DispatchWithoutAction } from 'react';
 import { MutableRefObject } from 'react';
 

--- a/build/api/ui.api.md
+++ b/build/api/ui.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="react" />
-
 import { AllHTMLAttributes } from 'react';
 import { AnimationEventHandler } from 'react';
 import { AriaRole } from 'react';

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"fast-glob": "^3.2.12",
 		"jsdom": "^17.0.0",
+		"json5": "^2.2.3",
 		"prettier": "2.3.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
 		"ae:test": "yarn workspaces foreach -pt run ae:test",
 		"build:js:prod": "yarn workspaces foreach run build",
 		"admin:pw:build": "yarn workspace @contember/admin run pw:build",
+		"admin:pw:preview": "yarn workspace @contember/admin run pw:preview",
+		"admin:pw:update": "yarn workspace @contember/admin run pw:update",
+		"admin:pw:report": "yarn workspace @contember/admin run pw:report",
 		"admin:pw:test": "yarn workspace @contember/admin run pw:test",
 		"vite": "cd packages/admin-sandbox && yarn run start",
 		"as:build": "yarn workspace @contember/admin-server run build"

--- a/packages/admin-i18n/src/ambient.d.ts
+++ b/packages/admin-i18n/src/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/admin/src/ambient.d.ts
+++ b/packages/admin/src/ambient.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="vite/client" />
-
 interface Document {
 	caretPositionFromPoint?: (x: number, y: number) => {
 		offsetNode: Node

--- a/packages/admin/src/components/bindingFacade/richText/editorSelection/useToolbarsState.ts
+++ b/packages/admin/src/components/bindingFacade/richText/editorSelection/useToolbarsState.ts
@@ -30,12 +30,11 @@ function updateToolbarStyle(container: HTMLDivElement, selectionState: EditorSel
 
 	if (domRangeRect) {
 		top = `${domRangeRect.top + window.pageYOffset - container.offsetHeight}px`
-		left = `${
-			Math.min(
-				Math.max(0, document.documentElement.clientWidth - container.offsetWidth),
-				Math.max(0, domRangeRect.left + window.pageXOffset - container.offsetWidth / 2 + domRangeRect.width / 2),
-			)
-		}px`
+		left = `${Math.min(
+			Math.max(0, document.documentElement.clientWidth - container.offsetWidth),
+			Math.max(0, domRangeRect.left + window.pageXOffset - container.offsetWidth / 2 + domRangeRect.width / 2),
+		)
+			}px`
 		maxWidth = `${document.documentElement.clientWidth}px`
 	} else {
 		top = '-1000vh'
@@ -69,7 +68,7 @@ export const useToolbarState = (): ToolbarsState => {
 
 	useEffect(() => {
 		const container = inlineToolbarRef.current
-		let timeoutId: NodeJS.Timeout
+		let timeoutId: ReturnType<typeof setTimeout>
 
 		function resize() {
 			if (!container) {

--- a/packages/binding/src/ambient.d.ts
+++ b/packages/binding/src/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/react-client/src/ambient.d.ts
+++ b/packages/react-client/src/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/react-utils/src/ambient.d.ts
+++ b/packages/react-utils/src/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/react-utils/src/hooks/useDebounceCallback.ts
+++ b/packages/react-utils/src/hooks/useDebounceCallback.ts
@@ -6,7 +6,7 @@ export const useDebounceCallback = (cb: () => any, debounceMs: number) => {
 	cbRef.current = cb
 
 	useEffect(() => {
-		return () => timerRef.current && clearTimeout(timerRef.current)
+		return () => clearTimeout(timerRef.current)
 	}, [])
 
 	return useCallback(() => {

--- a/packages/ui/src/ambient.d.ts
+++ b/packages/ui/src/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/vite-plugin/src/tsconfig.json
+++ b/packages/vite-plugin/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../../tsconfig.settings.json",
 	"compilerOptions": {
-		"outDir": "../dist/types"
+		"outDir": "../dist/types",
+		"types": ["node"],
 	}
 }

--- a/scripts/lint/module-import-linter.ts
+++ b/scripts/lint/module-import-linter.ts
@@ -1,7 +1,8 @@
-import ts from 'typescript'
-import * as fs from 'fs/promises'
-import { join, normalize } from 'path'
 import glob from 'fast-glob'
+import * as fs from 'fs/promises'
+import JSON5 from 'json5'
+import { join, normalize } from 'path'
+import ts from 'typescript'
 
 const globalModules = new Set(['vitest'])
 const allowedUnused = new Set([
@@ -19,7 +20,7 @@ const processPackage = async (dir: string, projectList: ProjectList) => {
 	const files = await glob(`${dir}/src/**/*.{ts,tsx}`, { onlyFiles: true })
 	const contents = await Promise.all(files.map(async (it): Promise<[file: string, content: string]> => [it, await fs.readFile(it, 'utf-8')]))
 	const imports = new Set<string>()
-	const errors: {file: string; message: string}[] = []
+	const errors: { file: string; message: string }[] = []
 	for (const [file, content] of contents) {
 		const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.ESNext)
 		sourceFile.forEachChild(node => {
@@ -118,8 +119,8 @@ interface Project {
 
 	const projects = await Promise.all(dirs.map(async (dir): Promise<Project> => {
 		try {
-			const packageJson = JSON.parse(await fs.readFile(`${dir}/package.json`, 'utf8'))
-			const tsconfig = JSON.parse(await fs.readFile(`${dir}/src/tsconfig.json`, 'utf8'))
+			const packageJson = JSON5.parse(await fs.readFile(`${dir}/package.json`, 'utf8'))
+			const tsconfig = JSON5.parse(await fs.readFile(`${dir}/src/tsconfig.json`, 'utf8'))
 			return {
 				dir,
 				name: packageJson.name,

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -20,6 +20,9 @@
 		"sourceMap": true,
 		"strict": true,
 		"target": "ES2020",
-		"useDefineForClassFields": true
+		"useDefineForClassFields": true,
+		"types": [
+			"vite/client"
+		]
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15660,7 +15660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.1, json5@npm:^2.2.2":
+"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.1, json5@npm:^2.2.2, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -19604,6 +19604,7 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     fast-glob: ^3.2.12
     jsdom: ^17.0.0
+    json5: ^2.2.3
     prettier: 2.3.2
     react: ^18.2.0
     react-dom: ^18.2.0


### PR DESCRIPTION
This adds type for `import.meta` to every package extending from base `tsconfig.json` and removes necessity to define types on per-package basis.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/488)
<!-- Reviewable:end -->
