### PR TITLE
format repeater label inside the item

### DIFF
--- a/build/api/admin.api.md
+++ b/build/api/admin.api.md
@@ -3583,7 +3583,7 @@ export interface RepeaterInnerProps<ContainerExtraProps, ItemExtraProps> extends
 }
 
 // @public (undocumented)
-export const RepeaterItem: React.MemoExoticComponent<({ children, canBeRemoved, label, removalType, dragHandleComponent }: RepeaterItemProps) => JSX.Element>;
+export const RepeaterItem: React.MemoExoticComponent<({ children, canBeRemoved, label, removalType, dragHandleComponent, index }: RepeaterItemProps) => JSX.Element>;
 
 // @public (undocumented)
 export interface RepeaterItemProps {

--- a/packages/admin/src/components/bindingFacade/collections/Repeater/RepeaterInner.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/Repeater/RepeaterInner.tsx
@@ -109,7 +109,7 @@ export const RepeaterInner = Component<RepeaterInnerProps<any, any>, NonStaticPr
 						<Entity accessor={entity} key={entity.key}>
 							<Item
 								{...props.itemComponentExtraProps!}
-								label={label ? `${label} #${i + 1}` : `#${i + 1}`}
+								label={label}
 								index={i}
 								createNewEntity={createNewEntity}
 								removalType={removalType}
@@ -152,7 +152,7 @@ export const RepeaterInner = Component<RepeaterInnerProps<any, any>, NonStaticPr
 							<Entity accessor={entity}>
 								<Item
 									{...props.itemComponentExtraProps!}
-									label={label ? `${label} #${i + 1}` : `#${i + 1}`}
+									label={label}
 									index={i}
 									createNewEntity={createNewEntity}
 									removalType={removalType}

--- a/packages/admin/src/components/bindingFacade/collections/Repeater/RepeaterItem.tsx
+++ b/packages/admin/src/components/bindingFacade/collections/Repeater/RepeaterItem.tsx
@@ -15,17 +15,21 @@ export interface RepeaterItemProps {
 }
 
 export const RepeaterItem = memo(
-	({ children, canBeRemoved, label, removalType, dragHandleComponent }: RepeaterItemProps) => {
+	({ children, canBeRemoved, label, removalType, dragHandleComponent, index }: RepeaterItemProps) => {
 		if (removalType !== 'delete') {
 			throw new BindingError(
 				`As a temporary limitation, <Repeater /> can currently only delete its items, not disconnect them. ` +
 					`This restriction is planned to be lifted sometime in future.`,
 			)
 		}
+		const labelWithIndex = index !== undefined
+			? <>{label}{label ? ` #${index + 1}` : `#${index + 1}`}</>
+			: label
+
 		return (
 			<RepeaterItemContainer
 				dragHandleComponent={dragHandleComponent}
-				label={label}
+				label={labelWithIndex}
 				actions={canBeRemoved ? <DeleteEntityButton /> : undefined}
 			>
 				{children}


### PR DESCRIPTION
this PR solves two issues with repeater label:
- wraps label with index in `<>` instead of casting to string, which corrupts non-string nodes
- formats the label it inside the item component, so user can override the behaviour by providing custom item component