### PR TITLE
Pr/admin components

### DIFF
--- a/ee/admin-server/public/_panel/pages/apiKeyCreate.tsx
+++ b/ee/admin-server/public/_panel/pages/apiKeyCreate.tsx
@@ -1,11 +1,11 @@
-import { CreateApiKeyForm, LayoutPage, NavigateBackButton, Page } from '@contember/admin'
+import { CreateApiKeyForm, Heading, LayoutPage, NavigateBackButton, Page } from '@contember/admin'
 
 export default (
 	<Page name="apiKeyCreate">
 		{({ project }: { project: string }) => (
 			<LayoutPage
 				navigation={<NavigateBackButton to={{ pageName: 'projectOverview', parameters: { project } }}>Project</NavigateBackButton>}
-				title={`Create API key for project ${project}`}
+				title={<Heading depth={1}>Create API key for project {project}</Heading>}
 			>
 				<CreateApiKeyForm
 					project={project}

--- a/ee/admin-server/public/_panel/pages/identityEdit.tsx
+++ b/ee/admin-server/public/_panel/pages/identityEdit.tsx
@@ -1,11 +1,11 @@
-import { EditIdentity, LayoutPage, NavigateBackButton, Page } from '@contember/admin'
+import { EditIdentity, Heading, LayoutPage, NavigateBackButton, Page } from '@contember/admin'
 
 export default (
 	<Page name="identityEdit">
 		{({ project, identity }: { project: string, identity: string }) => (
 			<LayoutPage
 				navigation={<NavigateBackButton to={{ pageName: 'projectOverview', parameters: { project } }}>Users</NavigateBackButton>}
-				title={`Edit membership in project ${project}`}
+				title={<Heading depth={1}>Edit membership in project {project}</Heading>}
 			>
 				<EditIdentity
 					project={project}

--- a/ee/admin-server/public/_panel/pages/projectCreate.tsx
+++ b/ee/admin-server/public/_panel/pages/projectCreate.tsx
@@ -1,8 +1,8 @@
-import { CreateProjectForm, LayoutPage, NavigateBackButton } from '@contember/admin'
+import { CreateProjectForm, Heading, LayoutPage, NavigateBackButton } from '@contember/admin'
 
 export default () => (
 	<LayoutPage
-		title="Create new project"
+		title={<Heading depth={1}>Create new project</Heading>}
 		navigation={<NavigateBackButton to={'projectList'}>Projects</NavigateBackButton>}
 		children={<CreateProjectForm projectListLink={'projectList'} />}
 	/>

--- a/ee/admin-server/public/_panel/pages/projectList.tsx
+++ b/ee/admin-server/public/_panel/pages/projectList.tsx
@@ -1,14 +1,14 @@
-import { LayoutPage, LinkButton, ProjectsGrid, useIdentity } from '@contember/admin'
+import { Heading, LayoutPage, LinkButton, ProjectsGrid, useIdentity } from '@contember/admin'
 
 export default () => {
 	const identity = useIdentity()
 	const actions = identity.permissions.canCreateProject
-		? <LinkButton to="projectCreate" distinction="primary">New project</LinkButton>
+		? <LinkButton to="projectCreate" distinction="primary" >New project</LinkButton>
 		: null
 
 	return (
 		<LayoutPage
-			title="Projects"
+			title={<Heading depth={1}>Projects</Heading>}
 			actions={actions}
 			children={(
 				<ProjectsGrid

--- a/ee/admin-server/public/_panel/pages/projectOverview.tsx
+++ b/ee/admin-server/public/_panel/pages/projectOverview.tsx
@@ -1,4 +1,4 @@
-import { ApiKeyList, LayoutPage, LinkButton, NavigateBackButton, Section, useCurrentRequest, UsersList } from '@contember/admin'
+import { ApiKeyList, Heading, LayoutPage, LinkButton, NavigateBackButton, Section, useCurrentRequest, UsersList } from '@contember/admin'
 
 export default () => {
 	const request = useCurrentRequest()!
@@ -6,7 +6,7 @@ export default () => {
 
 	return (
 		<LayoutPage
-			title={`Project ${project}`}
+			title={<Heading depth={1}>Project {project}</Heading>}
 			navigation={<NavigateBackButton to={'projectList'}>Projects</NavigateBackButton>}
 		>
 			<Section

--- a/ee/admin-server/public/_panel/pages/security.tsx
+++ b/ee/admin-server/public/_panel/pages/security.tsx
@@ -1,7 +1,7 @@
 import { Box, ChangePassword, Divider, Heading, LayoutPage, OtpManagement, Stack } from '@contember/admin'
 
 export default () => (
-	<LayoutPage title="Profile security">
+	<LayoutPage title={<Heading depth={1}>Profile security</Heading>}>
 		<Stack gap="large">
 			<ChangePassword />
 

--- a/ee/admin-server/public/_panel/pages/security.tsx
+++ b/ee/admin-server/public/_panel/pages/security.tsx
@@ -2,7 +2,7 @@ import { Box, ChangePassword, Divider, Heading, LayoutPage, OtpManagement, Stack
 
 export default () => (
 	<LayoutPage title="Profile security">
-		<Stack gap="xlarge">
+		<Stack gap="large">
 			<ChangePassword />
 
 			<Divider />

--- a/ee/admin-server/public/_panel/pages/studioForm.tsx
+++ b/ee/admin-server/public/_panel/pages/studioForm.tsx
@@ -3,6 +3,7 @@ import {
 	DataBindingProvider,
 	EntityId,
 	FeedbackRenderer,
+	Heading,
 	LayoutRenderer,
 	LinkButton,
 	PersistButton,
@@ -31,7 +32,7 @@ export default function StudioForm() {
 
 	return (
 		<DataBindingProvider stateComponent={FeedbackRenderer}>
-			<LayoutRenderer title={title} actions={actions}>
+			<LayoutRenderer title={<Heading depth={1}>{title}</Heading>} actions={actions}>
 				<AutoForm entity={entity} id={id} onCreateSuccess={onCreateSuccess} createEditLink={createEditLink} />
 			</LayoutRenderer>
 		</DataBindingProvider>

--- a/ee/admin-server/public/_panel/pages/studioGrid.tsx
+++ b/ee/admin-server/public/_panel/pages/studioGrid.tsx
@@ -3,6 +3,7 @@ import {
 	DataBindingProvider,
 	EntityId,
 	FeedbackRenderer,
+	Heading,
 	LayoutRenderer,
 	LinkButton,
 	PersistButton,
@@ -35,7 +36,7 @@ export default function StudioGrid() {
 
 	return (
 		<DataBindingProvider stateComponent={FeedbackRenderer}>
-			<LayoutRenderer title={`List ${entity}`} actions={actions} pageContentLayout="start">
+			<LayoutRenderer title={<Heading depth={1}>List {entity}</Heading>} actions={actions} pageContentLayout="stretch">
 				<AutoGrid entities={entities} createViewLinkTarget={createViewLinkTarget} createEditLinkTarget={createEditLinkTarget} />
 			</LayoutRenderer>
 		</DataBindingProvider>

--- a/ee/admin-server/public/_panel/pages/userInvite.tsx
+++ b/ee/admin-server/public/_panel/pages/userInvite.tsx
@@ -1,4 +1,4 @@
-import { InviteMethod, InviteUser, LayoutPage, NavigateBackButton, useCurrentRequest, useEnvironment } from '@contember/admin'
+import { Heading, InviteMethod, InviteUser, LayoutPage, NavigateBackButton, useCurrentRequest, useEnvironment } from '@contember/admin'
 
 export default () => {
 	const request = useCurrentRequest()!
@@ -9,7 +9,7 @@ export default () => {
 
 	return (
 		<LayoutPage
-			title={`Invite user to project ${project}`}
+			title={<Heading depth={1}>Invite user to project {project}</Heading>}
 			navigation={<NavigateBackButton to={{ pageName: 'projectOverview', parameters: { project } }}>Project</NavigateBackButton>}
 		>
 			<InviteUser

--- a/packages/admin/src/components/Auto/AutoGrid.tsx
+++ b/packages/admin/src/components/Auto/AutoGrid.tsx
@@ -1,6 +1,7 @@
 import { Component, QueryLanguage, Schema } from '@contember/binding'
-import { DataGrid, DataGridContainerPublicProps, DataGridProps, DeleteEntityButton, GenericCell } from '../bindingFacade'
+import { Stack } from '@contember/ui'
 import { LinkButton, RoutingLinkTarget } from '../../routing'
+import { DataGrid, DataGridContainerPublicProps, DataGridProps, DeleteEntityButton, GenericCell } from '../bindingFacade'
 import { AutoCell } from './AutoCell'
 
 export type AutoGridProps =
@@ -39,12 +40,14 @@ const createDataGridColumns = (
 
 	const actionColumn = (
 		<GenericCell key="action" shrunk>
-			{createEditLinkTarget && (
-				<LinkButton to={createEditLinkTarget(entityName)} distinction="seamless">
-					edit
-				</LinkButton>
-			)}
-			<DeleteEntityButton />
+			<Stack horizontal>
+				{createEditLinkTarget && (
+					<LinkButton to={createEditLinkTarget(entityName)} distinction="seamless" size="small">
+						edit
+					</LinkButton>
+				)}
+				<DeleteEntityButton />
+			</Stack>
 		</GenericCell>
 	)
 

--- a/packages/admin/src/components/Dev/IdentityPanel.tsx
+++ b/packages/admin/src/components/Dev/IdentityPanel.tsx
@@ -132,7 +132,7 @@ const LoginAsRole: FC = ({ }) => {
 			<Stack gap="large">
 				<EditMembership {...editUserMembershipProps} />
 
-				<Button distinction="primary" size="large" type="submit" disabled={isSubmitting}>
+				<Button display="block" distinction="primary" type="submit" disabled={isSubmitting}>
 					Login
 				</Button>
 			</Stack>

--- a/packages/admin/src/tenant/components/apiKey/CreateApiKeyForm.tsx
+++ b/packages/admin/src/tenant/components/apiKey/CreateApiKeyForm.tsx
@@ -68,7 +68,7 @@ export const CreateApiKeyForm: FC<CreateApiKeyFormProps> = ({ project, rolesConf
 
 				<EditMembership {...editUserMembershipProps} />
 
-				<Button distinction="primary" size="large" type="submit" disabled={isSubmitting}>
+				<Button display="block" distinction="primary" type="submit" disabled={isSubmitting}>
 					Create API key
 				</Button>
 			</Stack>

--- a/packages/admin/src/tenant/components/member/EditIdentity.tsx
+++ b/packages/admin/src/tenant/components/member/EditIdentity.tsx
@@ -72,7 +72,7 @@ export const EditIdentity: FC<EditIdentityProps> = ({ project, rolesConfig, iden
 			<Stack gap="large">
 				<EditMembership {...editUserMembershipProps} />
 
-				<Button distinction="primary" size="large" type="submit" disabled={isSubmitting}>
+				<Button display="block" distinction="primary" type="submit" disabled={isSubmitting}>
 					Save
 				</Button>
 			</Stack>

--- a/packages/admin/src/tenant/components/pages/EditUserPage.tsx
+++ b/packages/admin/src/tenant/components/pages/EditUserPage.tsx
@@ -1,8 +1,8 @@
-import { EditIdentity, RolesConfig } from '../member'
-import { NavigateBackButton, RoutingLinkTarget } from '../../../routing'
 import { useProjectSlug } from '@contember/react-client'
+import { Heading, LayoutPage } from '@contember/ui'
 import { FC, memo } from 'react'
-import { LayoutPage } from '@contember/ui'
+import { NavigateBackButton, RoutingLinkTarget } from '../../../routing'
+import { EditIdentity, RolesConfig } from '../member'
 
 export type EditUserPageProps = {
 	identityId: string
@@ -21,7 +21,7 @@ export const EditUserPage: FC<EditUserPageProps> = memo(
 		}
 		return (
 			<LayoutPage
-				title="Edit user"
+				title={<Heading depth={1}>Edit user</Heading>}
 				navigation={<NavigateBackButton to={userListLink}>Back to list of users</NavigateBackButton>}
 			>
 				<EditIdentity project={project} rolesConfig={rolesConfig} identityId={identityId} userListLink={userListLink} />

--- a/packages/admin/src/tenant/components/pages/InviteUserPage.tsx
+++ b/packages/admin/src/tenant/components/pages/InviteUserPage.tsx
@@ -1,9 +1,9 @@
-import { RolesConfig } from '../member'
+import { useProjectSlug } from '@contember/react-client'
+import { Heading, LayoutPage } from '@contember/ui'
+import { FC, memo } from 'react'
 import { NavigateBackButton, RoutingLinkTarget } from '../../../routing'
 import { InviteMethod } from '../../mutations'
-import { FC, memo } from 'react'
-import { useProjectSlug } from '@contember/react-client'
-import { LayoutPage } from '@contember/ui'
+import { RolesConfig } from '../member'
 import { InviteUser } from '../person'
 import { createNotInProjectError } from './errors'
 
@@ -23,7 +23,7 @@ export const InviteUserPage: FC<InviteUserPageProps> = memo(({ rolesConfig, user
 	}
 	return (
 		<LayoutPage
-			title="Invite user"
+			title={<Heading depth={1}>Invite user</Heading>}
 			navigation={<NavigateBackButton to={userListLink}>Back to list of users</NavigateBackButton>}
 		>
 			<InviteUser project={project} rolesConfig={rolesConfig} userListLink={userListLink} method={method} />

--- a/packages/admin/src/tenant/components/pages/UserListPage.tsx
+++ b/packages/admin/src/tenant/components/pages/UserListPage.tsx
@@ -1,8 +1,8 @@
-import { LinkButton, RoutingLinkTarget } from '../../../routing'
-import { useRoleRendererFactory, UseRoleRendererFactoryProps, UsersList } from '../person'
 import { useProjectSlug } from '@contember/react-client'
+import { Heading, LayoutPage } from '@contember/ui'
+import { LinkButton, RoutingLinkTarget } from '../../../routing'
+import { UseRoleRendererFactoryProps, UsersList, useRoleRendererFactory } from '../person'
 import { createNotInProjectError } from './errors'
-import { LayoutPage } from '@contember/ui'
 
 export type UserListPageProps<T> =
 	& UseRoleRendererFactoryProps<T>
@@ -23,7 +23,7 @@ export const UserListPage = <T extends {}>(props: UserListPageProps<T>) => {
 	return (
 		<LayoutPage
 			actions={<LinkButton to={props.addUserLink ?? 'tenantInviteUser'}>Add a user</LinkButton>}
-			title="Users in project"
+			title={<Heading depth={1}>Users</Heading>}
 		>
 			<UsersList
 				project={project}

--- a/packages/admin/src/tenant/components/person/Login.tsx
+++ b/packages/admin/src/tenant/components/person/Login.tsx
@@ -73,10 +73,10 @@ export const Login = ({ onLogin, resetLink }: LoginProps) => {
 					/>
 				</FieldContainer>}
 				<Stack horizontal align="center" justify="space-between">
-					<Button type="submit" distinction="primary" disabled={isSubmitting}>
+					{resetLink && <Link to={resetLink}>Forgot your password?</Link>}
+					<Button type="submit" distinction="primary" display="block" disabled={isSubmitting}>
 						Submit
 					</Button>
-					{resetLink && <Link to={resetLink}>Forgot your password?</Link>}
 				</Stack>
 			</Stack>
 		</form>

--- a/packages/admin/src/tenant/components/project/CreateProjectForm.tsx
+++ b/packages/admin/src/tenant/components/project/CreateProjectForm.tsx
@@ -77,7 +77,7 @@ export const CreateProjectForm: FC<CreateProjectFormProps> = ({ projectListLink 
 	}
 	return (
 		<form onSubmit={onSubmit}>
-			<Stack gap="xlarge">
+			<Stack gap="large">
 				<Heading depth={3}>New project</Heading>
 
 				<FieldContainer label={'Project slug'}>
@@ -89,8 +89,10 @@ export const CreateProjectForm: FC<CreateProjectFormProps> = ({ projectListLink 
 
 				<Divider />
 
-				<Heading depth={3}>Database credentials</Heading>
-				<p>You can leave some of this fields empty to use default values.</p>
+				<Stack gap="gap">
+					<Heading depth={3}>Database credentials</Heading>
+					<p>You can leave some of this fields empty to use default values.</p>
+				</Stack>
 
 				<FieldContainer label={'Host'}>
 					<TextInput {...register('dbHost')} />

--- a/packages/ui/src/components/Stack/Stack.tsx
+++ b/packages/ui/src/components/Stack/Stack.tsx
@@ -88,7 +88,7 @@ export const Stack = memo(forwardRef<HTMLDivElement, StackProps>(({
 	reverse = fallback(reverse, direction === 'horizontal-reverse' || direction === 'vertical-reverse', true)
 
 	// NOTE: When finally removing the direction prop, keep local variable `direction` for `data-direction` attribute
-	direction = fallback(direction, isDefined(horizontal), horizontal ? 'horizontal' : 'vertical')
+	direction = fallback(direction ?? 'vertical', isDefined(horizontal), horizontal ? 'horizontal' : 'vertical')
 	direction = fallback(direction, direction === 'horizontal-reverse', 'horizontal')
 	direction = fallback(direction, direction === 'vertical-reverse', 'vertical')
 

--- a/packages/ui/src/components/Stack/index.css
+++ b/packages/ui/src/components/Stack/index.css
@@ -17,6 +17,23 @@
 :where(.cui-stack[data-direction="horizontal"]) { flex-direction: row }
 :where(.cui-stack[data-direction="horizontal"][data-reverse]) { flex-direction: row-reverse }
 
+:where(
+	.cui-stack > h1,
+	.cui-stack > h2,
+	.cui-stack > h3,
+	.cui-stack > h4,
+	.cui-stack > h5,
+	.cui-stack > h6,
+	.cui-stack > p,
+	.cui-stack > figure,
+	.cui-stack > blockquote,
+	.cui-stack > dl,
+	.cui-stack > dd
+) {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
 :where(.cui-stack[data-gap]) { --cui-stack-gap: var(--cui-padding) }
 :where(.cui-stack[data-gap="gap"]) { --cui-stack-gap: var(--cui-gap) }
 :where(.cui-stack[data-gap="double"]) { --cui-stack-gap: var(--cui-double-gap) }


### PR DESCRIPTION
This PR improves several components from `@contember/admin` package, mostly uses in `@contember/admin-server` by

- wrapping string titles in `h1` tags in admin server & tenant pages
- replacing `xlarge` gap with large that is sufficient for optical spacing
- letting `Stack` control the gap by reseting margin on typographical/content tags, e.g. `p`
- aligning delete and delete buttons in grid table
- unifying primary submit buttons in forms
- moving `Submit` button in login on the right side (expected for positive actions)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/615)
<!-- Reviewable:end -->
