### PR TITLE
refactor(utilities): Add tests to deprecate utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-react": "^7.32.2",
 		"eslint-plugin-react-hooks": "^4.6.0",
-		"expect-type": "^0.16.0",
 		"fast-glob": "^3.2.12",
 		"jsdom": "^21.0.0",
 		"json5": "^2.2.3",

--- a/packages/utilities/src/deprecate/deprecate.ts
+++ b/packages/utilities/src/deprecate/deprecate.ts
@@ -24,7 +24,7 @@ export function deprecate(removal: SemverString, condition: boolean, deprecated:
 			if (shouldThrow) {
 				throw new Error(`Support for ${deprecated} was planned to be removed in the ${removal} release.${replacement ? ` Replace it with ${replacement} instead.` : 'Remove it.'}`)
 			} else {
-				console.warn(`Use of ${deprecated} is deprecated and might be removed in the next release.${replacement ? ` Use ${replacement} instead.` : 'There is no replacement.'}`)
+				console.warn(`Use of ${deprecated} is deprecated and might be removed in the next release.${replacement ? ` Use ${replacement} instead.` : ' There is no replacement.'}`)
 			}
 		}
 	}

--- a/packages/utilities/tests/deprecate/deprecate.test.ts
+++ b/packages/utilities/tests/deprecate/deprecate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vitest } from 'vitest'
+import { deprecate } from '../../src'
+
+describe('@contember/utilities.deprecate', () => {
+	it('logs a warning if the condition is true', () => {
+		const spy = vitest.spyOn(console, 'warn').mockImplementation(() => { })
+		deprecate('2.0.0', true, 'oldFeature', 'newFeature')
+		expect(spy).toHaveBeenCalledWith('Use of oldFeature is deprecated and might be removed in the next release. Use newFeature instead.')
+		spy.mockRestore()
+	})
+
+	it('throws an error if strict deprecations are enabled and the condition is true', () => {
+		const originalEnv = process.env
+		process.env = { ...originalEnv, VITE_CONTEMBER_ADMIN_STRICT_DEPRECATIONS: 'true' }
+		expect(() => {
+			deprecate('2.0.0', true, 'oldFeature', 'newFeature')
+		}).toThrow('Support for oldFeature was planned to be removed in the 2.0.0 release. Replace it with newFeature instead.')
+		process.env = originalEnv
+	})
+
+	it('does not log a warning if the condition is false', () => {
+		const spy = vitest.spyOn(console, 'warn').mockImplementation(() => { })
+		deprecate('2.0.0', false, 'oldFeature', 'newFeature')
+		expect(spy).not.toHaveBeenCalled()
+		spy.mockRestore()
+	})
+
+	it('does not throw an error if strict deprecations are enabled and the condition is false', () => {
+		const originalEnv = process.env
+		process.env = { ...originalEnv, VITE_CONTEMBER_ADMIN_STRICT_DEPRECATIONS: 'true' }
+		expect(() => {
+			deprecate('2.0.0', false, 'oldFeature', 'newFeature')
+		}).not.toThrow()
+		process.env = originalEnv
+	})
+
+	it('does not log a warning if the condition is true but the environment is not development', () => {
+		const originalEnv = process.env
+		process.env = { ...originalEnv, DEV: '' }
+		const spy = vitest.spyOn(console, 'warn').mockImplementation(() => { })
+		deprecate('2.0.0', true, 'oldFeature', 'newFeature')
+		expect(spy).not.toHaveBeenCalled()
+		spy.mockRestore()
+		process.env = originalEnv
+	})
+
+	it('logs a warning if the condition is true and replacement is null', () => {
+		const spy = vitest.spyOn(console, 'warn').mockImplementation(() => { })
+		deprecate('2.0.0', true, 'oldFeature', null)
+		expect(spy).toHaveBeenCalledWith('Use of oldFeature is deprecated and might be removed in the next release. There is no replacement.')
+		spy.mockRestore()
+	})
+})

--- a/packages/utilities/tests/deprecate/fallback.test.ts
+++ b/packages/utilities/tests/deprecate/fallback.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { fallback } from '../../src'
+
+describe('@contember/utilities.fallback', function () {
+	it('returns the fallback value if the condition is true', () => {
+		expect(fallback(1, true, 2)).equals(2)
+	})
+
+	it('returns the fallback value if the condition is true with correct union type', () => {
+		const border = 0 as boolean | 0 | 1 | 2 | 3 | 4 | 5
+		const border2 = fallback(border, border === 0, false)
+
+		expect(border2).equals(false)
+		expectTypeOf(border2).toEqualTypeOf<typeof border2>(false)
+	})
+
+	it('returns the value if the condition is false', () => {
+		expect(fallback(1, false, 2)).equals(1)
+	})
+})

--- a/packages/utilities/tests/types/Primitive.test.ts
+++ b/packages/utilities/tests/types/Primitive.test.ts
@@ -1,5 +1,4 @@
-import { expectTypeOf } from 'expect-type'
-import { describe, test } from 'vitest'
+import { describe, expectTypeOf, test } from 'vitest'
 import * as Types from '../../src/types'
 
 describe('@contember/utilities', () => {

--- a/packages/utilities/tests/types/RequiredDeepPlainObject.test.ts
+++ b/packages/utilities/tests/types/RequiredDeepPlainObject.test.ts
@@ -1,5 +1,4 @@
-import { expectTypeOf } from 'expect-type'
-import { describe, test } from 'vitest'
+import { describe, expectTypeOf, test } from 'vitest'
 import * as Types from '../../src/types'
 
 describe('@contember/utilities', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9941,13 +9941,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "expect-type@npm:0.16.0"
-  checksum: c1339e56fa1c997b104cc172579ace68fce4d4593421a5a5e85cbb26e280950d583c1e59064af6f1467743a1365aebfb5ddcdf220b94bee1895958c29081abb9
-  languageName: node
-  linkType: hard
-
 "express@npm:^4.17.3":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
@@ -14824,7 +14817,6 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-react: ^7.32.2
     eslint-plugin-react-hooks: ^4.6.0
-    expect-type: ^0.16.0
     fast-glob: ^3.2.12
     jsdom: ^21.0.0
     json5: ^2.2.3


### PR DESCRIPTION
This PR adds tests for deprecate utilities and replaces typescript test utility with one already included in `vitest` package with same API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/621)
<!-- Reviewable:end -->
