### PR TITLE
fix(ui): Add forgotten icons scale CSS when <= 1

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -249,6 +249,17 @@
 	stroke: none;
 }
 
+:where([data-overrides-lucide-icons] .lucide[scale^="0.0"]) { --cui-scale: 0.0 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.1"]) { --cui-scale: 0.1 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.2"]) { --cui-scale: 0.2 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.3"]) { --cui-scale: 0.3 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.4"]) { --cui-scale: 0.4 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.5"]) { --cui-scale: 0.5 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.6"]) { --cui-scale: 0.6 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.7"]) { --cui-scale: 0.7 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.8"]) { --cui-scale: 0.8 }
+:where([data-overrides-lucide-icons] .lucide[scale^="0.9"]) { --cui-scale: 0.9 }
+
 :where([data-overrides-lucide-icons] .lucide[scale="1"]) { --cui-scale: 1 }
 :where([data-overrides-lucide-icons] .lucide[scale^="1.0"]) { --cui-scale: 1.0 }
 :where([data-overrides-lucide-icons] .lucide[scale^="1.1"]) { --cui-scale: 1.1 }


### PR DESCRIPTION
This PR adds scales for icons that were meant to be present in 1.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/623)
<!-- Reviewable:end -->
