### PR TITLE
fix(ui): Reorder CSS

### DIFF
--- a/packages/ui/src/components/Editor/EditorCanvas.css
+++ b/packages/ui/src/components/Editor/EditorCanvas.css
@@ -23,10 +23,6 @@
 	box-shadow: var(--cui-box-shadow--controls-focus-ring);
 }
 
-:where(.cui-editorCanvas.view-hovering-toolbar *[contenteditable=true]) {
-	padding-bottom: calc(56px + 10 * var(--cui-gap));
-}
-
 :where(.cui-editorCanvas-canvas > [class^=cui-editor]) {
 	padding-bottom: 0;
 	padding-left: var(--cui-editor-canvas--padding-element-left);
@@ -45,6 +41,10 @@
 	gap: var(--cui-editor-blocks-gap);
 	padding-bottom: var(--cui-editor-canvas--padding-element-bottom);
 	padding-top: var(--cui-editor-canvas--padding-element-top);
+}
+
+:where(.cui-editorCanvas.view-hovering-toolbar *[contenteditable=true]) {
+	padding-bottom: calc(56px + 10 * var(--cui-gap));
 }
 
 :where(.cui-editorCanvas-canvas) {


### PR DESCRIPTION
This PR fixes regression where the bottom padding reserving space for hovering toolbar is overridden by the CSS rules that follow later.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/634)
<!-- Reviewable:end -->
