### PR TITLE
fix(ui): Restrict setting style to positions on left and right

### DIFF
--- a/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
+++ b/packages/ui/src/components/Forms/FieldContainer/FieldContainer.tsx
@@ -218,10 +218,12 @@ export const FieldContainer = memo(
 					colorSchemeClassName(useColorScheme()),
 					classNameProp,
 				])}
-				style={useMemo(() => ({
-					'--cui-field-container--body-content-height': px(height),
-					...style,
-				}), [height, style])}
+				style={useMemo(() => labelPosition === 'left' || labelPosition === 'right'
+					? ({
+						'--cui-field-container--body-content-height': px(height),
+						...style,
+					})
+					: style, [height, labelPosition, style])}
 			>
 				{(label || labelDescription) && (
 					<span className={className('header')}>


### PR DESCRIPTION
This PR resolves unintended setting of min height on `FieldContainer` label sub-container in cases where it is not required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/637)
<!-- Reviewable:end -->
