### PR TITLE
fix(react-datagrid): pass env as a static context when analyzing cells

### DIFF
--- a/packages/react-datagrid/src/grid/createDataGrid.tsx
+++ b/packages/react-datagrid/src/grid/createDataGrid.tsx
@@ -35,7 +35,7 @@ const dummyStateMethods: DataGridStateMethods = {
 }
 
 const createInitialState = (props: DataGridProps<{}>, environment: Environment): DataGridState<any> => {
-	const columns = extractDataGridColumns(props.children)
+	const columns = extractDataGridColumns(props.children, environment)
 	return {
 		columns,
 		paging: {

--- a/packages/react-datagrid/src/internal/gridTemplateAnalyzer.ts
+++ b/packages/react-datagrid/src/internal/gridTemplateAnalyzer.ts
@@ -2,6 +2,7 @@ import { ChildrenAnalyzer, Leaf } from '@contember/react-multipass-rendering'
 import type { ReactNode } from 'react'
 import { DataGridColumnProps, DataGridColumns } from '../types'
 import { DataGridColumn } from '../grid'
+import { Environment } from '@contember/react-binding'
 
 class BoxedGridColumnProps {
 	public constructor(public readonly value: DataGridColumnProps) {}
@@ -9,13 +10,13 @@ class BoxedGridColumnProps {
 
 const gridColumnLeaf = new Leaf(node => new BoxedGridColumnProps(node.props), DataGridColumn)
 
-const gridTemplateAnalyzer = new ChildrenAnalyzer<BoxedGridColumnProps>([gridColumnLeaf], {
+const gridTemplateAnalyzer = new ChildrenAnalyzer<BoxedGridColumnProps, never, Environment>([gridColumnLeaf], {
 	ignoreUnhandledNodes: false,
 	unhandledNodeErrorMessage: `DataGrid: encountered an illegal child node.`,
 })
 
-export const extractDataGridColumns = (nodes: ReactNode): DataGridColumns<any> => {
-	const processed = gridTemplateAnalyzer.processChildren(nodes, undefined)
+export const extractDataGridColumns = (nodes: ReactNode, env: Environment): DataGridColumns<any> => {
+	const processed = gridTemplateAnalyzer.processChildren(nodes, env)
 
 	let counter = 0
 	const suffixes: Record<string, number> = {}

--- a/packages/react-datagrid/src/internal/useDataGridState.ts
+++ b/packages/react-datagrid/src/internal/useDataGridState.ts
@@ -18,7 +18,7 @@ export const DATA_GRID_DEFAULT_ITEMS_PER_PAGE = 50
 export const useDataGridState = (props: Pick<DataGridProps<{ tile?: unknown }>, 'children' | 'itemsPerPage' | 'entities' | 'dataGridKey' | 'tile'>): [DataGridState<any>, DataGridStateMethods] => {
 	const dataGridKey = useDataGridKey(props)
 	const environment = useEnvironment()
-	const columns = useMemo(() => extractDataGridColumns(props.children), [props.children])
+	const columns = useMemo(() => extractDataGridColumns(props.children, environment), [environment, props.children])
 	const [pageState, updatePaging] = useGridPagingState(props.itemsPerPage ?? DATA_GRID_DEFAULT_ITEMS_PER_PAGE, dataGridKey)
 	const [hiddenColumns, setIsColumnHidden] = useHiddenColumnsState(columns, dataGridKey)
 	const [orderDirections, setOrderBy] = useOrderBys(columns, updatePaging, dataGridKey)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/interface/646)
<!-- Reviewable:end -->
